### PR TITLE
Fix React prop typing in ThemeProvider and UI components

### DIFF
--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -6,6 +6,10 @@ import {
   type ThemeProviderProps,
 } from 'next-themes'
 
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+type ThemeProviderWithChildren = ThemeProviderProps & {
+  children: React.ReactNode
+}
+
+export function ThemeProvider({ children, ...props }: ThemeProviderWithChildren) {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>
 }

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -25,13 +25,15 @@ const badgeVariants = cva(
   },
 )
 
+type BadgeProps = React.ComponentPropsWithoutRef<'span'> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }
+
 function Badge({
   className,
   variant,
   asChild = false,
   ...props
-}: React.ComponentProps<'span'> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+}: BadgeProps) {
   const Comp = asChild ? Slot : 'span'
 
   return (

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -35,22 +35,24 @@ const buttonVariants = cva(
   },
 )
 
+type ButtonProps = React.ComponentPropsWithoutRef<'button'> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }
+
 function Button({
   className,
   variant,
   size,
   asChild = false,
   ...props
-}: React.ComponentProps<'button'> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
+}: ButtonProps) {
   const Comp = asChild ? Slot : 'button'
 
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(buttonVariants({ variant, size }), className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- declare a ThemeProvider props type that guarantees a ReactNode child when passing through to `next-themes`
- narrow the Badge/Button component props to `ComponentPropsWithoutRef` so Slot usage no longer produces invalid ref types
- clean up button variant composition to keep custom class names separate from the variant options

## Testing
- npx tsc --noEmit
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccbc5cbbc0832c8306898a3ce7f8b2